### PR TITLE
Avoid lint debugger

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Documentation:
   Enabled: false
 
+Lint/Debugger:
+  Enabled: false
+
 Metrics/LineLength:
   Max: 80
 


### PR DESCRIPTION
```
def method
  p 'very
binding.pry # let me here, I need you baby...
  p 'good'
end
```

Quando colocamos um debugger no código, queremos o debugger no código. (: