### PR TITLE
Revome profile running by default

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --colour
 --format=documentation
+--no-profile


### PR DESCRIPTION
- Atrapalha muito a visualização padrão do `profile`! Não é possível ver quais testes falaram na primeira olhada.

- A opção `--profile` está por padrão na versão do rspec do gaara.

- Esse PR também adequaria o output do rspec do gaara com os outros

sem --no--profile:
![captura de tela de 2017-06-01 19-40-45](https://cloud.githubusercontent.com/assets/1172532/26703892/43b9c902-4702-11e7-9767-0aeabb56d84d.png)

com --no--profile:

![captura de tela de 2017-06-01 19-41-49](https://cloud.githubusercontent.com/assets/1172532/26703917/666bf344-4702-11e7-8e40-2daea74ac1bd.png)
