### PR TITLE
Add alphabetical sort on properties config

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -39,17 +39,7 @@ rules:
   property-sort-order:
     - 1
     -
-      order:
-        - display
-        - margin
-        - padding
-        - width
-        - height
-        - position
-        - top
-        - right
-        - bottom
-        - left
+      order: alphabetical
       ignore-custom-properties: true
   variable-name-format:
     - 2

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -15,6 +15,9 @@ rules:
   no-vendor-prefixes: 0
   no-color-literals: 2
   no-color-keywords: 2
+  no-qualifying-elements:
+    - 1
+    - allow-element-with-attribute: true
   no-duplicate-properties: 1
   quotes:
     - 2
@@ -36,11 +39,6 @@ rules:
     - 2
     -
       size: 2
-  property-sort-order:
-    - 1
-    -
-      order: alphabetical
-      ignore-custom-properties: true
   variable-name-format:
     - 2
     -


### PR DESCRIPTION
Adicionei a ordenação alfabética de propriedades a cada escopo e já está funcionando como o esperado.

O que precisamos lidar agora é com ordenação de **includes** e **propriedades que começam com -**.

Por exemplo:

```css
.content {
  max-width: 100%;
  -webkit-font-smoothing: antialiased;
}

// ou

.content {
  -webkit-font-smoothing: antialiased;
  max-width: 100%;
}

// Não faz diferença pro lint 😕
```

Bom, se for possível arrumar isso, 🔝

Senão, só com um plugin do PostCSS mesmo, mas não sei a viabilidade de adicionar isso ao projeto, já que usamos o sprockets.