### PR TITLE
Change double quotes to single

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,10 @@ Metrics/LineLength:
   Max: 80
 
 Style/StringLiterals:
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space


### PR DESCRIPTION
Conforme conversado na guilda, estou abrindo o PR para alterarmos o nosso style guide relacionado ao uso de aspas duplas e simples.

Acredito que essa alteração traz um beneficio para nós durante o code-review, pois utilizando aspas simples, saberemos de antemão que não há a possibilidade de ter interpolação na string, sendo a dupla usada para o uso de interpolação, servindo como um flag que ali pode ter algo que pode dar problema.