### PR TITLE
Revert "Enables rubocop-rspec"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,3 @@
-require: rubocop-rspec
-
 Documentation:
   Enabled: false
 


### PR DESCRIPTION
Reverts getninjas/dotfiles#11

O commit força todos os projetos a terem o rubocop-rspec passando em todos os specs, mesmo nos antigos. Existem soluções melhores, como:
 * Ao rodar o rubocop especificar o rubocop-rspec: `rubocop --require rubocop-rspec`
 * Adicionar ao rubocop.yml do projeto o require: `require: rubocop-rspec`

Existem projetos que não passam no semaphore se o rubocop não aprovar