### PR TITLE
Revert "Change double quotes to single"

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,10 +5,10 @@ Metrics/LineLength:
   Max: 80
 
 Style/StringLiterals:
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
 
 Style/StringLiteralsInInterpolation:
-  EnforcedStyle: single_quotes
+  EnforcedStyle: double_quotes
 
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space


### PR DESCRIPTION
Reverts getninjas/dotfiles#10

Notei que ainda estamos utilizando o mesmo padrão de antes, que é aspas duplas, então não há ganho em continuar com aspas simples.