### PR TITLE
Update max line lenght

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ Documentation:
   Enabled: false
 
 Metrics/LineLength:
-  Max: 80
+  Max: 120
 
 Style/StringLiterals:
   EnforcedStyle: double_quotes


### PR DESCRIPTION
80 Linhas é um padrão meio antiquado e as vezes difícil de manter.

120 me parece um bom novo padrão e é o MAX_LENTH do slip diff do github