### PR TITLE
Use progress (the default) rspec formatter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --colour
---format=documentation
+--format=progress
 --no-profile


### PR DESCRIPTION
This way of formatting the specs is simpler and shorter, there is
no need for the documentation mode to run all the time, and the
developer can change the format for especif runs