### PR TITLE
rubocop has to work on different ruby versions

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,4 +48,3 @@ AllCops:
     - "Rakefile"
     - "config/boot.rb"
     - "README.md"
-  TargetRubyVersion: 2.3


### PR DESCRIPTION
não deixa o rubocop explicito para o ruby 2.3