### PR TITLE
Allow trailing comma in arrays and hashes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,12 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
 
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
 AllCops:
   Exclude:
     - "bin/**/*"


### PR DESCRIPTION
Arrays:
```ruby
# bad
a = [1, 2,]

# good
a = [
  1,
  2,
]
```
hashes:
```ruby
# bad
a = { foo: 1, bar: 2, }

# good
a = {
  foo: 1,
  bar: 2,
}
```