### PR TITLE
[RuboCop] Layout/AlignArguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,23 +1,18 @@
 Documentation:
   Enabled: false
 
-Metrics/LineLength:
-  Max: 120
-
-Style/StringLiterals:
-  EnforcedStyle: double_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
-
-SpaceAroundEqualsInParameterDefault:
-  EnforcedStyle: space
-
-Style/PercentQLiterals:
-  EnforcedStyle: upper_case_q
-
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*"
+
+Metrics/LineLength:
+  Max: 120
 
 Style/Lambda:
   EnforcedStyle: literal
@@ -30,9 +25,14 @@ Style/PercentLiteralDelimiters:
     '%w': '[]'
     '%W': '[]'
 
-Metrics/BlockLength:
-  Exclude:
-    - "spec/**/*"
+Style/PercentQLiterals:
+  EnforcedStyle: upper_case_q
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: double_quotes
 
 AllCops:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,9 @@
 Documentation:
   Enabled: false
 
+Layout/AlignArguments:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/AlignParameters:
   EnforcedStyle: with_fixed_indentation
 


### PR DESCRIPTION
RuboCop v0.68 adicionou um novo cop _Layout/AlignArguments_ https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutalignarguments

A config mais comum que usamos é _with_fixed_indentation_, deixando padrão aqui.

---

RuboCop v0.68 added a new cop _Layout/AlignArguments_ https://rubocop.readthedocs.io/en/stable/cops_layout/#layoutalignarguments_

The most common style we follow is _with_fixed_indentation_, making it default.