### PR TITLE
[RuboCop] Use the default style for Layout/AlignParameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,9 +16,6 @@ SpaceAroundEqualsInParameterDefault:
 Style/PercentQLiterals:
   EnforcedStyle: upper_case_q
 
-Layout/AlignParameters:
-  EnforcedStyle: with_fixed_indentation
-
 Style/Lambda:
   EnforcedStyle: literal
 


### PR DESCRIPTION
In PR #18 we preferred the default style for Layout/AlignArguments, since the Layout/AlignParameters is very similar we should use the same rule for consistency.