### PR TITLE
[Proposal] Change rule to named variables in SCSS

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -42,7 +42,7 @@ rules:
   variable-name-format:
     - 2
     -
-      convention: camelcase
+      convention: hyphenatedlowercase
   space-between-parens:
     - 2
     -


### PR DESCRIPTION
We currently use `camelCase` to name our variables in` SCSS`, but looking at `Niten` we use a `hyphenatedlowercase` convention.

This my PR is a proposal to change this convention.

Example:

camelCase: `$fontSizeXXS`
hyphenatedlowercase: `$font-size-xxs`