### PR TITLE
Uses snake case on variable number

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,9 @@ Metrics/BlockLength:
   Exclude:
     - "spec/**/*"
 
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma
 


### PR DESCRIPTION
Doc: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Naming/VariableNumber

```
# bad

variable1 = 1

# good

variable_1 = 1
```