### PR TITLE
Using hyphenatedlowercase no variable name format

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -42,7 +42,7 @@ rules:
   variable-name-format:
     - 2
     -
-      convention: camelcase
+      convention: hyphenatedlowercase
   space-between-parens:
     - 2
     -


### PR DESCRIPTION
We was discuting about implement a `hyphenatedbem` format to use in our projects.

Tanya, our front-end view render in nodejs, is using this format on the last PRs. The ideia is to moving for this format in our project and fixing gradually.

Waiting for approval of our @getninjas/frontend team :)