### PR TITLE
Adding allow-leading-underscore to sass-lint class-name-format config

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -75,6 +75,7 @@ rules:
     - 2
     -
       convention: hyphenatedbem
+      allow-leading-underscore: true
   mixins-before-declarations:
     - 2
     -


### PR DESCRIPTION
Using `__` on bem convention causes a break on our codeclimate config.

This PR allow this option on sass files.