### PR TITLE
Removing selector-class-pattern config of sass-lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -11,7 +11,6 @@ files:
 
 # Rule Configuration
 rules:
-  selector-class-pattern: null
   no-transition-all: 0
   no-vendor-prefixes: 0
   no-color-literals: 2


### PR DESCRIPTION
Removing selector-class-pattern on sass-lint rules. This option requires a regex pattern.

https://stylelint.io/user-guide/rules/selector-class-pattern