### PR TITLE
Habilita RSpec and Performance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,7 @@
+require:
+  - rubocop-performance
+  - rubocop-rspec
+
 AllCops:
   Exclude:
     - bin/*


### PR DESCRIPTION
Habilita os cops do RSpec e do Performance (Rails).

Instalar essas gems não quebra nada, pois é de `development`, mas se por algum motivo não possa instalar no projeto no momento, dá pra instalar global sem commitar no Gemfile.

Em algum momento precisamos introduzir esses plugins.