### PR TITLE
RSpec feature false positive

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,6 +41,18 @@ Metrics/LineLength:
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 
+RSpec/EmptyExampleGroup:
+  Exclude:
+    - spec/factories/*
+
+RSpec/EmptyLineAfterExampleGroup:
+  Exclude:
+    - spec/factories/*
+
+RSpec/MissingExampleGroupArgument:
+  Exclude:
+    - spec/factories/*
+
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
 


### PR DESCRIPTION
O código a seguir é um campo, não a chave `feature` do RSpec.
Porém a pasta do FactoryBot não precisa desse Cop ativo, deixando o problema de lado.

```rb
feature { "value" }
```