### PR TITLE
Enables Multiple Expectation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,6 +37,9 @@ Metrics/LineLength:
 Naming/VariableNumber:
   EnforcedStyle: snake_case
 
+RSpec/MultipleExpectations:
+  Enabled: false
+
 SpaceAroundEqualsInParameterDefault:
   EnforcedStyle: space
 


### PR DESCRIPTION
Fazer múltiplas expectations é muito útil quando queremos verificar vários atributos de um mesmo objeto que foi atualizado ou testar métodos do Capybara onde reaproveitamos o mesmo setup/boot para fazer várias afirmações em uma mesma página. Criar uma verificação para um teste apenas é bem bonito na teoria, mas na prática nem sempre vale a pena, logo acredito que terão testes que serão apenas uma verificação, outros várias, já que o mesmo método pode modificar várias coisas de um mesmo subject.