### PR TITLE
[Stylelint] Create base configuration

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,12 @@
+{
+  "extends": "stylelint-config-sass-guidelines",
+  "rules": {
+    "selector-class-pattern": [
+      "^[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*(?:__[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*){0,1}(?:(?:--)[a-zA-Z0-9]+(?:-[a-zA-Z0-9]+)*){0,1}$",
+      {
+        "resolveNestedSelectors": true,
+        "message": "Expected class selector to match BEM naming convention"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
First draft of the configuration. In this PR we opted to extend a configuration based on [Sass Guidelines](https://sass-guidelin.es/). It contains mostly stylistic configurations. Based on this, we can extend this configuration to put the more granular conventions used on Getninjas.