### PR TITLE
[GUILDA-893]  Altera double_quotes para single_quotes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -71,10 +71,10 @@ Style/PercentQLiterals:
   EnforcedStyle: upper_case_q
 
 Style/StringLiterals:
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 Style/StringLiteralsInInterpolation:
-  EnforcedStyle: double_quotes
+  EnforcedStyle: single_quotes
 
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
**Motivação**
Foi discutido na última guilda de backend (09/04/2021) que mudariamos o padrão doconfigurado no rubocop para aspas simples e não duplas.

**Changelog**

- Altera  double_quotes para  single_quotes no .rubocop.yml

**Exemplos**
_EnforcedStyle: single_quotes (default)_
```(ruby)
# bad
"No special symbols"
"No string interpolation"
"Just text"

# good
'No special symbols'
'No string interpolation'
'Just text'
"Wait! What's #{this}!"
```

_EnforcedStyle: single_quotes (default)_
```(ruby)
# bad
result = "Tests #{success ? "PASS" : "FAIL"}"

# good
result = "Tests #{success ? 'PASS' : 'FAIL'}"
````
**Card**
[GUILDA-893](https://gogogoninjas.atlassian.net/browse/GUILDA-893)