### PR TITLE
Permitindo até 4 seletores no css

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -5,6 +5,7 @@
     "order/properties-alphabetical-order": null,
     "function-parentheses-space-inside": "never-single-line",
     "declaration-property-value-disallowed-list": null,
+    "selector-max-compound-selectors": 4,
     "order/properties-order": [
       {
         "groupName": "all",


### PR DESCRIPTION
Apos analisar os projetos foi visto que usamos até 4 seletores encadeados, se precisar aumentar isso vale a pena analisar os componentes com intuito de extrair em outros arquivos, para evitar código hadouken