### PR TITLE
[FRONT-474] stylelint update

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,11 +1,20 @@
 {
-  "extends": "stylelint-config-sass-guidelines",
-  "plugins": ["stylelint-declaration-strict-value"],
+  "extends": [
+    "stylelint-config-sass-guidelines",
+    "stylelint-config-concentric-order"
+  ],
+  "plugins": [
+    "stylelint-declaration-strict-value",
+    "stylelint-scss"
+  ],
   "rules": {
-    "order/properties-alphabetical-order": null,
-    "function-parentheses-space-inside": "never-single-line",
     "declaration-property-value-disallowed-list": null,
+    "order/properties-alphabetical-order": null,
+    "function-parentheses-space-inside": null,
     "selector-max-compound-selectors": 4,
+    "value-no-vendor-prefix": null,
+    "property-no-vendor-prefix": null,
+    "selector-no-vendor-prefix": null,
     "order/properties-order": [
       {
         "groupName": "all",
@@ -368,7 +377,7 @@
       }
     ],
     "max-nesting-depth": [
-      3,
+      4,
       {
         "ignoreAtRules": ["each", "media", "supports", "include"]
       }
@@ -383,7 +392,14 @@
       ["/color$/", "text-decoration"],
       {
         "expandShorthand": true,
-        "ignoreValues": ["0", "transparent", "inherit", "initial", "underline", "none"]
+        "ignoreValues": [
+          "0",
+          "transparent",
+          "inherit",
+          "initial",
+          "underline",
+          "none"
+        ]
       }
     ],
     "selector-class-pattern": [


### PR DESCRIPTION
**MOTIVATION**
Ao atualizar as dependências de stylelint e stylelint-config-sass-guidelines dos projetos, surgiu a necessidade de ajustar algumas regras do arquivo.stylelintrc.json, onde a regra function-parentheses-space-inside foi descontinuada e foi preciso adicionar a configuração para properties-alphabetical-order.


**CHANGELOG**
  - `stylelint`: alterações de configurações de regras de lint


**CARDS**
[FRONT-474](https://gogogoninjas.atlassian.net/browse/FRONT-474)

**PRINTS**
❌ 

**TASKS**
- [x] Garantir que os nomes de arquivos não possuem acentuação
- [x] Garantir que a branch atual está atualizada com a ultima versão da master
