### PR TITLE
Atualizar o .prettierrc do Dotfiles

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "semi": true,
-  "trailingComma": "all",
+  "trailingComma" : "es5",
   "singleQuote": true,
   "printWidth": 80,
   "tabWidth": 2,


### PR DESCRIPTION
**MOTIVATION**
Essa PR altera alterar o `traillingComma` do `.prettierrc` de `all` para `es5` para evitar que o prettier adicione virgulas`(,)` em funções e parâmetros de funções.

**CHANGELOG**
- `.prettierrc` -> Alterando o `traillingComma` de `all` para `es5`;